### PR TITLE
[FEAT] ember-3x-codemods for version 3.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,9 +40,7 @@
     },
     "projectOptions": ["app", "addon"],
     "nodeVersion": "6.0.0",
-    "commands": [
-       "ember-3x-codemods notify-property-change app/**/*.js"
-    ]
+    "commands": ["ember-3x-codemods notify-property-change app/**/*.js"]
   },
   "qunit-dom-codemod": {
     "versions": {

--- a/manifest.json
+++ b/manifest.json
@@ -32,9 +32,7 @@
     },
     "projectOptions": ["app", "addon"],
     "nodeVersion": "4.0.0",
-    "commands": [
-      " github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js"
-    ]
+    "commands": ["github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js"]
   },
   "notify-property-change": {
     "versions": {

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
       "ember-source": "3.1.0-beta.1"
     },
     "projectOptions": ["app", "addon"],
-    "nodeVersion": "4.0.0",
+    "nodeVersion": "6.0.0",
     "commands": [
        "ember-3x-codemods notify-property-change app/**/*.js"
     ]

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,16 @@
     "projectOptions": ["app", "addon"],
     "nodeVersion": "4.0.0",
     "commands": [
-      " github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js",
+      " github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js"
+    ]
+  },
+  "ember-3x-codemods": {
+    "versions": {
+      "ember-source": "3.1.0-beta.1"
+    },
+    "projectOptions": ["app", "addon"],
+    "nodeVersion": "4.0.0",
+    "commands": [
        "ember-3x-codemods notify-property-change app/**/*.js"
     ]
   },

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,10 @@
     },
     "projectOptions": ["app", "addon"],
     "nodeVersion": "4.0.0",
-    "commands": ["github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js"]
+    "commands": [
+      " github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js",
+       "ember-3x-codemods notify-property-change app/**/*.js"
+    ]
   },
   "qunit-dom-codemod": {
     "versions": {

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
       " github:rondale-sc/es5-getter-ember-codemod es5-getter-ember-codemod app/**/*.js"
     ]
   },
-  "ember-3x-codemods": {
+  "notify-property-change": {
     "versions": {
       "ember-source": "3.1.0-beta.1"
     },


### PR DESCRIPTION
#21 
Use notifyPropertyChange instead of propertyWillChange and propertyDidChange
[Deprecations Added in 3.1](https://deprecations.emberjs.com/v3.x/#toc_use-notifypropertychange-instead-of-propertywillchange-and-propertydidchange)

### Input
```js
Ember.propertyWillChange(object, 'someProperty');
doStuff(object);
Ember.propertyDidChange(object, 'someProperty');

object.propertyWillChange('someProperty');
doStuff(object);
object.propertyDidChange('someProperty');
```

## Output
```js
doStuff(object);
Ember.notifyPropertyChange(object, 'someProperty');

doStuff(object);
object.notifyPropertyChange('someProperty');
```
