### PR TITLE
[FEAT] Adding deprecate-merge codemod for 3.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -50,4 +50,12 @@
     "nodeVersion": "6.0.0",
     "commands": ["jscodeshift -t https://raw.githubusercontent.com/simplabs/qunit-dom-codemod/master/qunit-dom-codemod.js ./tests"]
   }
+  "deprecate-merge-codemod": {
+    "versions": {
+      "ember-cli": "3.6.0-beta.1"
+    },
+    "projectOptions": ["app", "addon"],
+    "nodeVersion": "6.0.0",
+    "commands": ["ember-3x-codemods deprecate-merge app/**/*.js"]
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -49,7 +49,7 @@
     "projectOptions": ["app", "addon"],
     "nodeVersion": "6.0.0",
     "commands": ["jscodeshift -t https://raw.githubusercontent.com/simplabs/qunit-dom-codemod/master/qunit-dom-codemod.js ./tests"]
-  }
+  },
   "deprecate-merge-codemod": {
     "versions": {
       "ember-cli": "3.6.0-beta.1"


### PR DESCRIPTION
#21 
Ember.merge predates Ember.assign, but since Ember.assign has been released, Ember.merge has been mostly unnecessary. To cut down on duplication, we are now recommending using Ember.assign instead of Ember.merge.
[ember-polyfills.deprecate-merge](https://deprecations.emberjs.com/v3.x#toc_ember-polyfills-deprecate-merge)

# Before
```js
import { merge } from '@ember/polyfills';

var a = { first: 'Yehuda' };
var b = { last: 'Katz' };
merge(a, b); // a == { first: 'Yehuda', last: 'Katz' }, b == { last: 'Katz' }
```
# After
```js
import { assign } from '@ember/polyfills';

var a = { first: 'Yehuda' };
var b = { last: 'Katz' };
assign(a, b); // a == { first: 'Yehuda', last: 'Katz' }, b == { last: 'Katz' }
```

Before merge :

- [x] get this passing https://github.com/ember-cli/ember-cli-update/pull/709