### PR TITLE
[FEAT] Add cp-property-map codemod

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -81,5 +81,13 @@
     "projectOptions": ["app", "addon"],
     "nodeVersion": "6.0.0",
     "commands": ["ember-3x-codemods cp-volatile app/**/*.js"]
+  },
+  "cp-property-map-codemod": {
+    "versions": {
+      "ember-cli": "3.8.0-beta.1"
+    },
+    "projectOptions": ["app", "addon"],
+    "nodeVersion": "6.0.0",
+    "commands": ["ember-3x-codemods cp-property-map app/**/*.js"]
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -84,7 +84,7 @@
   },
   "cp-property-map-codemod": {
     "versions": {
-      "ember-cli": "3.8.0-beta.1"
+      "ember-cli": "3.9.0-beta.1"
     },
     "projectOptions": ["app", "addon"],
     "nodeVersion": "6.0.0",

--- a/manifest.json
+++ b/manifest.json
@@ -84,7 +84,7 @@
   },
   "cp-property-map-codemod": {
     "versions": {
-      "ember-cli": "3.9.0-beta.1"
+      "ember-source": "3.9.0-beta.1"
     },
     "projectOptions": ["app", "addon"],
     "nodeVersion": "6.0.0",


### PR DESCRIPTION
#21 
In the case of the filter, map, and sort computed property macros, it was previously possible to need to add dependencies because they weren't available in the public APIs of those macros. An optional second parameter has now been added to these macros which is an array of additional dependent keys, allowing you to pass these dependencies to them:

## before
```js
const Person = EmberObject.extend({
  friendNames: map('friends', function(friend) {
    return friend[this.get('nameKey')];
  }).property('nameKey')
});
```

## after
```js
const Person = EmberObject.extend({
  friendNames: map('friends', ['nameKey'], function(friend) {
    return friend[this.get('nameKey')];
  })
});
```