### PR TITLE
[FEAT] Add fpe-observes codemod

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -89,5 +89,13 @@
     "projectOptions": ["app", "addon"],
     "nodeVersion": "6.0.0",
     "commands": ["ember-3x-codemods cp-property-map app/**/*.js"]
+  },
+  "fpe-observes-codemod": {
+    "versions": {
+      "ember-source": "3.11.0-beta.1"
+    },
+    "projectOptions": ["app", "addon"],
+    "nodeVersion": "6.0.0",
+    "commands": ["ember-3x-codemods fpe-observes app/**/*.js"]
   }
 }


### PR DESCRIPTION
#21 

# Function.prototype.observes

Historically, Ember has extended the Function.prototype with a few functions (on, observes, property), over time we have moved away from using these prototype extended functions in favor of using the official ES modules based API.

## Before
```js
import EmberObject from '@ember/object';

export default EmberObject.extend({
  valueObserver: function() {
    // Executes whenever the "value" property changes
  }.observes('value')
});
```
## After
```js
import EmberObject, { observer } from '@ember/object';

export default EmberObject.extend({
  valueObserver: observer('value', function() {
    // Executes whenever the "value" property changes
  })
});
```