### PR TITLE
fix: ember-quit-codemod fails with non-js files

### DIFF
--- a/packages/addon/manifest.json
+++ b/packages/addon/manifest.json
@@ -11,7 +11,7 @@
       "ember-cli": ">=3.0.0-beta.1"
     },
     "nodeVersionRange": ">=4",
-    "commands": ["ember-qunit-codemod convert-module-for-to-setup-test ./tests/"]
+    "commands": ["ember-qunit-codemod convert-module-for-to-setup-test ./tests/**/*.js"]
   },
   "ember-test-helpers-codemod": {
     "versionRanges": {

--- a/packages/app/manifest.json
+++ b/packages/app/manifest.json
@@ -11,7 +11,7 @@
       "ember-cli": ">=3.0.0-beta.1"
     },
     "nodeVersionRange": ">=4",
-    "commands": ["ember-qunit-codemod convert-module-for-to-setup-test ./tests/"]
+    "commands": ["ember-qunit-codemod convert-module-for-to-setup-test ./tests/**/*.js"]
   },
   "ember-test-helpers-codemod": {
     "versionRanges": {


### PR DESCRIPTION
Fixes #126