### PR TITLE
chore: update angle-brackets codemod to use latest version

### DIFF
--- a/packages/addon/manifest.json
+++ b/packages/addon/manifest.json
@@ -84,7 +84,7 @@
       "ember-source": ">=3.10.0-beta.1"
     },
     "nodeVersionRange": ">=8",
-    "commands" : ["ember-angle-brackets-codemod@2 angle-brackets addon/templates tests/dummy/app/templates"]
+    "commands" : ["ember-angle-brackets-codemod addon/templates tests/dummy/app/templates"]
   },
   "fpe-on-codemod": {
     "versionRanges": {

--- a/packages/app/manifest.json
+++ b/packages/app/manifest.json
@@ -84,7 +84,7 @@
       "ember-source": ">=3.10.0-beta.1"
     },
     "nodeVersionRange": ">=8",
-    "commands" : ["ember-angle-brackets-codemod@2 angle-brackets app/templates"]
+    "commands" : ["ember-angle-brackets-codemod app/templates"]
   },
   "fpe-on-codemod": {
     "versionRanges": {


### PR DESCRIPTION
1. Remove v2 tag from the codemod invocation
2. Remove the transform name since the angle brackets transform has been
made default in the codemod

Fixes #171 