### PR TITLE
Revert "chore: skip es5-getter-ember-codemod in linux"

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -113,10 +113,6 @@ describe('runs codemods', function() {
         this.skip();
       }
 
-      if (['es5-getter-ember-codemod'].includes(codemod) && ['linux'].includes(process.platform)) {
-        this.skip();
-      }
-
       async function _merge(src, dest) {
         await fs.copy(
           path.join(codemodsFixturesPath, codemod, src, commitMessage),


### PR DESCRIPTION
This reverts commit 8ff5101b143d058842fd3e244d508cbd5220563f.